### PR TITLE
fix macro ElVar naming convention 

### DIFF
--- a/UIATreeInspector.ahk
+++ b/UIATreeInspector.ahk
@@ -207,6 +207,17 @@ class TreeInspector {
             return
         processName := WinGetProcessName(this.Stored.hWnd)
         winElVariable := RegExMatch(processName, "^[^ .\d]+", &match:="") ? match[] "El" : "winEl"
+        if not IsAlnum(winElVariable){
+            lengthElVariable := StrLen(winElVariable)
+            cleanedVar := ""
+            loop lengthElVariable {
+                char := SubStr(winElVariable, A_Index, 1)
+                if IsAlnum(char) {
+                    cleanedVar .= char
+                }
+            }
+            winElVariable := cleanedVar
+        }
         winTitle := "`"" WinGetTitle(this.Stored.hWnd) " ahk_exe " processName "`""
         winElText := winElVariable " := UIA.ElementFromHandle(" (this.Stored.Controls.Has(ctrl := this.Stored.hWnd) ? "ControlGetHwnd(`"" ControlGetClassNN(ctrl, this.Stored.Controls[ctrl]) "`", " winTitle ")" : winTitle) ")"
         if !InStr(this.EditMacroScript.Text, winElText) || RegExMatch(this.EditMacroScript.Text, "\Q" winElText "\E(?=[\w\W]*\QwinEl := UIA.ElementFromHandle(`"ahk_exe\E)")


### PR DESCRIPTION
Hi there, 

We spoke long ago about the UIA v1, hope you are well.

Screenshot below enumerates small issue in non-AlphaNumeric process names for the TreeInspector's macro ElVar naming convention. I know some Regex, but could not at glance, without translation, look at your regex and identify a small tweak that would correct this issue. I have presented my own fix for naming of non-alphanum chars. Feel free to throw out my fix if you can make a small tweak, I presented a quick solution in the case that this is not the case. I have also written the code in a verbose manner, it could be compressed. Thanks!

# issue

![image](https://github.com/Descolada/UIA-v2/assets/98753696/fd8f577d-7c09-498f-a3f5-544b788935b1)


# fix

```autohotkey 
        winElVariable := RegExMatch(processName, "^[^ .\d]+", &match:="") ? match[] "El" : "winEl"
        if not IsAlnum(winElVariable){
            lengthElVariable := StrLen(winElVariable)
            cleanedVar := ""
            loop lengthElVariable {
                char := SubStr(winElVariable, A_Index, 1)
                if IsAlnum(char) {
                    cleanedVar .= char
                }
            }
            winElVariable := cleanedVar
        }
```



![image](https://github.com/Descolada/UIA-v2/assets/98753696/173825f0-c8dc-4fed-9645-941646392d9c)

