### PR TITLE
Expand collapse

### DIFF
--- a/Lib/UIA.ahk
+++ b/Lib/UIA.ahk
@@ -7731,17 +7731,19 @@ class Viewer {
         while ItemID := this.TVUIA.GetNext(ItemID, "Full")
             this.TVUIA.Modify(ItemID, expandCollapse)
         FocusId := this.TVUIA.isCollapsed ? FocusId : this.TVUIA.GetNext()
-        this.TVUIA.Modify(FocusId, "Select")
+        this.TVUIA.Modify(FocusId, "Select Vis")
         this.TVUIA.Opt("+Redraw")
         this.TVUIA.IsCollapsed := !this.TVUIA.IsCollapsed
     }
     TVUIA_FocusElement(GuiCtrlObj,*) {
         FocusId := this.TVUIA.GetSelection()
         ItemId := 0
+        this.TVUIA.Opt("-Redraw")
         while ItemID := this.TVUIA.GetNext(ItemID, "Full") ; Collapse all elements.
             this.TVUIA.Modify(ItemID, "-Expand")
+        this.TVUIA.Modify(FocusId, "Select Vis") ; Reselect the item, which also expands the parents
+        this.TVUIA.Opt("+Redraw")
         this.TVUIA.IsCollapsed := true
-        this.TVUIA.Modify(FocusId, "Select") ; Reselect the item, which also expands the parents
     }
     ; Handles filtering the UIA elements inside the TreeView when the text hasn't been changed in 500ms.
     ; Sorts the results by UIA properties.


### PR DESCRIPTION
Hi Descolada!
Thanks for accepting my first ever PR. Made my day! FWIW I'm a nurse that's ended up in health IT... so far from a software developer, but trying to dig into things a bit deeper.
Also thank you for the advice re `#SingleInstance Force`. I threw it in there to avoid the alert when I was testing my changes, but definitely good to keep in mind for the library. Out of interest is there a nice way of handling the alert when launching the viewer? Or is stuck that way as UIA is a library first and viewer application second?
Finally toggling the redraw feels so much nicer. Great tip!

You've inspired me to make a few more small tweaks you can take if you like the behaviour.

List view element is selected when right clicked - When attempting to focus an element I found myself frequently right clicking without selecting the element first, usually with the root element still selected, collapsing everything.
When selecting expand all from a partially expanded tree, right clicked element remains selected and visible.
Added the redraw toggle to `TVUIA_FocusElement()` as now I know the trick, it is noticeably smoother.
