### PR TITLE
Fixed GetAllPropertyValues() bug

### DIFF
--- a/Lib/UIA.ahk
+++ b/Lib/UIA.ahk
@@ -1,4 +1,4 @@
-﻿/*
+ ﻿/*
     Introduction & credits
     This library implements Microsoft's UI Automation framework.
     Microsoft's official documentation:: https://docs.microsoft.com/en-us/windows/win32/winauto/entry-uiauto-win32
@@ -3681,8 +3681,12 @@ class IUIAutomationElement extends UIA.IUIAutomationBase {
     ; This gets called when Element.Property is used
     GetPropertyValue(propertyId) {
         local val
-        if !IsNumber(propertyId)
-            try propertyId := UIA.Property.%propertyId%
+        if IsObject(propertyId)
+            return
+        if !IsNumber(propertyId) {
+            try
+                propertyId := UIA.Property.%propertyId%
+        }
         ComCall(10, this, "int", propertyId, "ptr", val := UIA.ComVar())
         return val[] is ComObjArray ? UIA.SafeArrayToAHKArray(val[]) : val[]
     }

--- a/Lib/UIA.ahk
+++ b/Lib/UIA.ahk
@@ -1,4 +1,4 @@
- ﻿/*
+﻿/*
     Introduction & credits
     This library implements Microsoft's UI Automation framework.
     Microsoft's official documentation:: https://docs.microsoft.com/en-us/windows/win32/winauto/entry-uiauto-win32

--- a/Lib/UIA.ahk
+++ b/Lib/UIA.ahk
@@ -3483,6 +3483,8 @@ class IUIAutomationElement extends UIA.IUIAutomationBase {
     GetAllPropertyValues() {
         local infos := {}, k, v, arr, t
         for k, v in UIA.Property.OwnProps() {
+            if k = "__CachedValues"
+                continue
             v := this.GetPropertyValue(v)
             if (v is ComObjArray) {
                 arr := []
@@ -3681,11 +3683,11 @@ class IUIAutomationElement extends UIA.IUIAutomationBase {
     ; This gets called when Element.Property is used
     GetPropertyValue(propertyId) {
         local val
-        if IsObject(propertyId)
-            return
         if !IsNumber(propertyId) {
-            try
+            if Type(propertyId) = "String"
                 propertyId := UIA.Property.%propertyId%
+            else
+                throw ValueError("Invalid ``propertyId``; Value must be an integer or string.", -1, "Type(input) == " Type(propertyID))
         }
         ComCall(10, this, "int", propertyId, "ptr", val := UIA.ComVar())
         return val[] is ComObjArray ? UIA.SafeArrayToAHKArray(val[]) : val[]

--- a/Lib/UIA.ahk
+++ b/Lib/UIA.ahk
@@ -3684,10 +3684,10 @@ class IUIAutomationElement extends UIA.IUIAutomationBase {
     GetPropertyValue(propertyId) {
         local val
         if !IsNumber(propertyId) {
-            if Type(propertyId) = "String"
+            if UIA.Property.HasOwnProp(propertyId)
                 propertyId := UIA.Property.%propertyId%
             else
-                throw ValueError("Invalid ``propertyId``; Value must be an integer or string.", -1, "Type(input) == " Type(propertyID))
+                throw ValueError("Invalid propertyId.", -1, IsObject(propertyId) ? "PropertyId must be a string or an integer, but " Type(propertyId) " was provided" : propertyId)
         }
         ComCall(10, this, "int", propertyId, "ptr", val := UIA.ComVar())
         return val[] is ComObjArray ? UIA.SafeArrayToAHKArray(val[]) : val[]


### PR DESCRIPTION
When calling `GetAllPropertyValues()`, the `__CachedValues` property gets included in the loop. I added a conditional to skip that, and also added better error handling in `GetPropertyValue()`.