### PR TITLE
Fix JSGetElementPos

### DIFF
--- a/Lib/UIA_Browser.ahk
+++ b/Lib/UIA_Browser.ahk
@@ -626,17 +626,17 @@ class UIA_Browser {
 	
 	; Uses Javascript's querySelector to get a Javascript element and then its position. useRenderWidgetPos=True uses position of the Chrome_RenderWidgetHostHWND1 control to locate the position element relative to the window, otherwise it uses UIA_Browsers CurrentDocumentElement position.
     JSGetElementPos(selector, useRenderWidgetPos:=False) { ; based on code by AHK Forums user william_ahk
-        local js := "
-        (LTrim
+        local js := Format("
+        (LTrim Join
 			(() => {
-				let bounds = document.querySelector("%selector%").getBoundingClientRect().toJSON();
+				let bounds = document.querySelector("{1}").getBoundingClientRect().toJSON();
 				let zoom = window.devicePixelRatio.toFixed(2);
 				for (const key in bounds) {
 					bounds[key] = bounds[key] * zoom;
 				}
 				return JSON.stringify(bounds);
 			})()
-        )"
+        )", selector)
         local bounds_str := this.JSReturnThroughClipboard(js)
         RegexMatch(bounds_str, "`"x`":(\d+).?\d*?,`"y`":(\d+).?\d*?,`"width`":(\d+).?\d*?,`"height`":(\d+).?\d*?", &size)
 		if useRenderWidgetPos {


### PR DESCRIPTION
Now uses v2 syntax for continuation sections and Format for inserting the selector.