### PR TITLE
Update UIA.ahk

### DIFF
--- a/Lib/UIA.ahk
+++ b/Lib/UIA.ahk
@@ -43,9 +43,7 @@
     To-do:
     - Better error handling
 */
-global IUIAutomationMaxVersion := IUIAutomationMaxVersion ?? 7
-    , IUIAutomationActivateScreenReader := IUIAutomationActivateScreenReader ?? 1
-    , IUIAutomationDllPath := IUIAutomationDllPath ?? ""
+
 
 if !A_IsCompiled && A_LineFile = A_ScriptFullPath
     UIA.Viewer()
@@ -58,7 +56,9 @@ class UIA {
  * variable, which by default is set to the latest available UIA version.
  */
 static __New() {
-    global IUIAutomationMaxVersion
+    global IUIAutomationMaxVersion := IUIAutomationMaxVersion ?? 7
+    , IUIAutomationActivateScreenReader := IUIAutomationActivateScreenReader ?? 1
+    , IUIAutomationDllPath := IUIAutomationDllPath ?? ""
     this.IUIAutomationVersion := IUIAutomationMaxVersion+1, this.ptr := 0
     ; The following is a partial head-way into making the UIA class name-agnostic (that is, making it possible to rename and reference UIA more easily, eg when wrapped inside inside another class).
     ; UIA static methods have been converted this way, but IUIAutomationElement runs into a problem: namely the syntax highlighter is unable to detect that IUIAutomationElement has been made to


### PR DESCRIPTION
Move this: 
```ahk
    global IUIAutomationMaxVersion := IUIAutomationMaxVersion ?? 7
    , IUIAutomationActivateScreenReader := IUIAutomationActivateScreenReader ?? 1
    , IUIAutomationDllPath := IUIAutomationDllPath ?? ""
```
into static __New of the UIA class.

Doing this ensures that all global variables are initialized as intended, also if a script returns before the UIA.ahk code (I usually return before all #Include definitions. 

I'm unsure if the below code should also be moved (but it suffers the same fate as the first code, but unlike the variables, this code wont cause an error) , I personally think that code should instead be moved to an example script file. UIA.ahk should just contain the class to be included by another script, without doing anything on its own. 
```ahk
if !A_IsCompiled && A_LineFile = A_ScriptFullPath
    UIA.Viewer()
```

I have currently just kept it where it is. 